### PR TITLE
fix(toAscii): add nukta combination mappings to single character

### DIFF
--- a/lib/toAscii.js
+++ b/lib/toAscii.js
@@ -13,6 +13,15 @@ const mappings = Object
     : acc
   ), [] )
 
+// Replacement for Akhar + Nutka with single character
+const nuktaMappings = [
+  [ 'sæ', 'S' ],
+  [ 'Kæ', '^' ],
+  [ 'gæ', 'Z' ],
+  [ 'jæ', 'z' ],
+  [ 'Pæ', '&' ],
+  [ 'læ', 'L' ],
+]
 
 // Replacement rules for correcting converted unicode.
 const postReplacements = [
@@ -27,18 +36,13 @@ const postReplacements = [
   [ /MØI/ug, 'µØI' ], // Use centered tippi on top of spacer char
   [ /([@R®H´ÍÏçœ˜†])u/ug, '$1ü' ], // Use lower aunkar when char is pair akhar
   [ /([@R®H´ÍÏçœ˜†])U/ug, '$1¨' ], // Use lower dulankaar when char is pair akhar
-  [ 'sæ', 'S' ],
-  [ 'Kæ', '^' ],
-  [ 'gæ', 'Z' ],
-  [ 'jæ', 'z' ],
-  [ 'Pæ', '&' ],
-  [ 'læ', 'L' ],
 ]
 
 // Precompute the replacements and mappings
 const finalReplacements = [
   [ /(.)ਿ਼/ug, '$1਼ਿ' ], // Move nukta from sihari
   ...mappings,
+  ...nuktaMappings,
   ...postReplacements,
 ]
 

--- a/lib/toAscii.js
+++ b/lib/toAscii.js
@@ -18,7 +18,7 @@ const mappings = Object
 const postReplacements = [
   [ /(.)i/ug, 'i$1' ], // Switch position of sihari
   [ /wN/ug, 'W' ], // Replace bindi, khana with single khana with bindi char
-  [ /(.)i([R®H§´ÍÏçœ˜†])/ug, 'i$1$2' ], // Switch sihari position when pair akhars exist
+  [ /(.)i([R®H§´ÍÏçœ˜†Î])/ug, 'i$1$2' ], // Switch sihari position when pair akhars exist
   [ /kR/ug, 'k®' ], // Replace K pair rara with correct rara
   [ /([nl])M/ug, '$1µ' ], // Replace tippi with correct tippi char
   [ /i([nl])µ/ug, 'i$1M' ], // Replace tippi with correct tippi char in sihari case
@@ -27,7 +27,6 @@ const postReplacements = [
   [ /MØI/ug, 'µØI' ], // Use centered tippi on top of spacer char
   [ /([@R®H´ÍÏçœ˜†])u/ug, '$1ü' ], // Use lower aunkar when char is pair akhar
   [ /([@R®H´ÍÏçœ˜†])U/ug, '$1¨' ], // Use lower dulankaar when char is pair akhar
-  [ /(.)iÎ/ug, 'i$1Î' ], // Swap i with Î
   [ 'sæ', 'S' ],
   [ 'Kæ', '^' ],
   [ 'gæ', 'Z' ],

--- a/lib/toAscii.js
+++ b/lib/toAscii.js
@@ -28,6 +28,12 @@ const postReplacements = [
   [ /([@R®H´ÍÏçœ˜†])u/ug, '$1ü' ], // Use lower aunkar when char is pair akhar
   [ /([@R®H´ÍÏçœ˜†])U/ug, '$1¨' ], // Use lower dulankaar when char is pair akhar
   [ /(.)iÎ/ug, 'i$1Î' ], // Swap i with Î
+  [ 'sæ', 'S' ],
+  [ 'Kæ', '^' ],
+  [ 'gæ', 'Z' ],
+  [ 'jæ', 'z' ],
+  [ 'Pæ', '&' ],
+  [ 'læ', 'L' ],
 ]
 
 // Precompute the replacements and mappings

--- a/test/toAscii.spec.js
+++ b/test/toAscii.spec.js
@@ -28,6 +28,7 @@ const words = [
   [ 'ਦੁਰਲਭੰ ਏਕ ਭਗਵਾਨ ਨਾਮਹ ਨਾਨਕ ਲਬਧੵਿੰ ਸਾਧਸੰਗਿ ਕ੍ਰਿਪਾ ਪ੍ਰਭੰ ॥੩੫॥', 'durlBM eyk Bgvwn nwmh nwnk lbiD´M swDsMig ik®pw pRBM ]35]' ],
   [ 'ਜੇਨ ਕਲਾ ਸਸਿ ਸੂਰ ਨਖੵਤ੍ਰ ਜੋਤੵਿੰ ਸਾਸੰ ਸਰੀਰ ਧਾਰਣੰ ॥', 'jyn klw sis sUr nK´qR joiq´M swsM srIr DwrxM ]' ],
   [ 'ਬਸੵਿੰਤ ਰਿਖਿਅੰ ਤਿਆਗਿ ਮਾਨੰ ॥', 'bis´Mq iriKAM iqAwig mwnµ ]' ],
+  [ 'ਸ਼ ਖ਼ ਗ਼ ਜ਼ ਫ਼ ਲ਼', 'S ^ Z z & L' ],
 ]
 
 describe( 'toAscii()', () => {


### PR DESCRIPTION
### Summary of PR
Adds mappings for `akhar + nukta` to single ascii character

### Linked issues
Fix #146