### PR TITLE
Add stripEndings

### DIFF
--- a/README.hbs
+++ b/README.hbs
@@ -29,6 +29,7 @@ const {
   toShahmukhi,
   stripAccents,
   stripVishraams,
+  stripEndings
   isGurmukhi,
 } = require( 'gurmukhi-utils' )
 
@@ -41,7 +42,8 @@ toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ �
 toShahmukhi('ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ') // => هر هر هر گُنی
 stripAccents('ਜ਼ਫ਼ੈਸ਼ਸ') // => ਜਫੈਸਸ
 stripVishraams('sbid mrY. so mir rhY; iPir.') // => sbid mrY so mir rhY iPir
-isGurmukhi('ਗੁਰਮੁਖੀ') // t=> true
+stripEndings('ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ ॥੧॥ ਰਹਾਉ ॥') // => ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ
+isGurmukhi('ਗੁਰਮੁਖੀ') // => true
 ```
 
 Additionally, the package is available for web use via [unpkg CDN](https://unpkg.com/gurmukhi-utils).

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Want to play around? [![Try gurmukhi-utils on RunKit](https://badge.runkitcdn.co
 ## API
 
 ### firstLetters(line, [stripNukta], [withVishraams]) ⇒ <code>String</code>
-Generates the first letters for a given ASCII or unicode Gurmukhi string.By default, the function will transform letters with bindi to their simple equivalent,for example, zaza to jaja (ਜ਼ => ਜ).
+Generates the first letters for a given ASCII or unicode Gurmukhi string.
+By default, the function will transform letters with bindi to their simple equivalent,
+for example, zaza to jaja (ਜ਼ => ਜ).
 
 **Returns**: <code>String</code> - The first letters of each word in the provided Gurmukhi line.  
 
@@ -118,10 +120,12 @@ Checks if first char in string is part of the Gurmukhi Unicode block.
 
 **Example**  
 ```js
-isGurmukhi('ਗੁਰਮੁਖੀ') // => trueisGurmukhi('gurmuKI') // => false
+isGurmukhi('ਗੁਰਮੁਖੀ') // => true
+isGurmukhi('gurmuKI') // => false
 ```
 ### stripAccents(text) ⇒ <code>String</code>
-Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.Useful for generalising search queries.
+Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.
+Useful for generalising search queries.
 
 **Returns**: <code>String</code> - A simplified version of the provided Gurmukhi string.  
 
@@ -131,7 +135,8 @@ Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.Usef
 
 **Example**  
 ```js
-stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳstripAccents('Z^Svb') // => gKsvb
+stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳ
+stripAccents('Z^Svb') // => gKsvb
 ```
 ### stripVishraams(text, options) ⇒ <code>String</code>
 Removes the specified vishraams from a string.
@@ -171,10 +176,12 @@ Converts Gurmukhi unicode text to ASCII, used GurmukhiAkhar font.
 
 **Example**  
 ```js
-toAscii('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => hmw swieil luqi& hk prvrS ]toAscii('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => su bYiT iekMqR ]578]
+toAscii('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => hmw swieil luqi& hk prvrS ]
+toAscii('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => su bYiT iekMqR ]578]
 ```
 ### toEnglish(line) ⇒ <code>String</code>
-Transliterates a line from Unicode Gurmukhi to english.Currently supports the `,`, `;`, `.` vishraam characters.
+Transliterates a line from Unicode Gurmukhi to english.
+Currently supports the `,`, `;`, `.` vishraam characters.
 
 **Returns**: <code>String</code> - The English transliteration of the provided Gurmukhi line.  
 
@@ -201,7 +208,8 @@ Transliterates Unicode Gurmukhi text to Hindi (Devanagari script).
 
 **Example**  
 ```js
-toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥') // => कुल जन मधे मिल्यो सारग पान रे ॥toHindi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => सु बैठ इकंत्र ॥५७८॥
+toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥') // => कुल जन मधे मिल्यो सारग पान रे ॥
+toHindi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => सु बैठ इकंत्र ॥५७८॥
 ```
 ### toShahmukhi(text) ⇒ <code>String</code>
 Transliterates Unicode Gurmukhi text to the Shahmukhi script.
@@ -214,7 +222,8 @@ Transliterates Unicode Gurmukhi text to the Shahmukhi script.
 
 **Example**  
 ```js
-toShahmukhi('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => هما ساِال لُتف هک پرورش ۔۔toShahmukhi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => سُ بَےٹھ ِاکںتر ۔۔۵۷۸۔۔
+toShahmukhi('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => هما ساِال لُتف هک پرورش ۔۔
+toShahmukhi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => سُ بَےٹھ ِاکںتر ۔۔۵۷۸۔۔
 ```
 ### toUnicode(text) ⇒ <code>String</code>
 Converts ASCII text used in the GurmukhiAkhar font to Unicode.
@@ -227,7 +236,8 @@ Converts ASCII text used in the GurmukhiAkhar font to Unicode.
 
 **Example**  
 ```js
-toUnicode('kul jn mDy imil´o swrg pwn ry ]') // => ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥toUnicode('su bYiT iekMqR ]578]') // => ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥
+toUnicode('kul jn mDy imil´o swrg pwn ry ]') // => ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥
+toUnicode('su bYiT iekMqR ]578]') // => ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Want to speak with us? <p>[![Slack](https://slack.shabados.com/badge.svg)](https
   * [firstLetters(line, [stripNukta], [withVishraams]) ⇒ String](#firstlettersline-stripnukta-withvishraams-%E2%87%92-string)
   * [isGurmukhi(text, [exhaustive]) ⇒ boolean](#isgurmukhitext-exhaustive-%E2%87%92-boolean)
   * [stripAccents(text) ⇒ String](#stripaccentstext-%E2%87%92-string)
+  * [stripEndings(text) ⇒ String](#stripendingstext-%E2%87%92-string)
   * [stripVishraams(text, options) ⇒ String](#stripvishraamstext-options-%E2%87%92-string)
   * [toAscii(text) ⇒ String](#toasciitext-%E2%87%92-string)
   * [toEnglish(line) ⇒ String](#toenglishline-%E2%87%92-string)
@@ -45,6 +46,7 @@ const {
   toShahmukhi,
   stripAccents,
   stripVishraams,
+  stripEndings
   isGurmukhi,
 } = require( 'gurmukhi-utils' )
 
@@ -57,7 +59,8 @@ toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ �
 toShahmukhi('ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ') // => هر هر هر گُنی
 stripAccents('ਜ਼ਫ਼ੈਸ਼ਸ') // => ਜਫੈਸਸ
 stripVishraams('sbid mrY. so mir rhY; iPir.') // => sbid mrY so mir rhY iPir
-isGurmukhi('ਗੁਰਮੁਖੀ') // t=> true
+stripEndings('ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ ॥੧॥ ਰਹਾਉ ॥') // => ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ
+isGurmukhi('ਗੁਰਮੁਖੀ') // => true
 ```
 
 Additionally, the package is available for web use via [unpkg CDN](https://unpkg.com/gurmukhi-utils).
@@ -137,6 +140,35 @@ Useful for generalising search queries.
 ```js
 stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳ
 stripAccents('Z^Svb') // => gKsvb
+```
+### stripEndings(text) ⇒ <code>String</code>
+Strips line endings from any Gurmukhi or translation string.
+Accepts both Unicode and ASCII input.
+Useful for generating accurate first letters or modifying non-Gurbani for better display.
+*Not* designed for headings or Sirlekhs.
+
+**Returns**: <code>String</code> - A ending-less version of the text.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| text | <code>String</code> | The text to stip endings from. |
+
+**Example** *(Line ending phrases)*  
+```js
+stripEndings('ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ ॥੧॥ ਰਹਾਉ ॥') // => ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ
+stripEndings('ਹੁਕਮੁ ਪਛਾਣਿ; ਤਾ ਖਸਮੈ ਮਿਲਣਾ ॥੧॥ ਰਹਾਉ ਦੂਜਾ ॥') // => ਹੁਕਮੁ ਪਛਾਣਿ; ਤਾ ਖਸਮੈ ਮਿਲਣਾ
+stripEndings('ਜਨ ਨਾਨਕ. ਗੁਰਮੁਖਿ ਜਾਤਾ ਰਾਮ ॥੪॥੬॥ ਛਕਾ ੧ ॥') // => ਜਨ ਨਾਨਕ. ਗੁਰਮੁਖਿ ਜਾਤਾ ਰਾਮ
+```
+**Example** *(English Translations)*  
+```js
+stripEndings('O Nanak, Forever And Ever True. ||1||') // => O Nanak, Forever And Ever True.
+stripEndings('lush greenery. ||1||Pause||') // => lush greenery.
+stripEndings('always I live within the Khalsa. 519') // => always I live within the Khalsa.
+stripEndings('without your reminiscence.(1) (3)') // => without your reminiscence.
+```
+**Example** *(Spanish Translations)*  
+```js
+stripEndings('ofrece su ser en sacrificio a Ti. (4-2-9)') // => ofrece su ser en sacrificio a Ti.
 ```
 ### stripVishraams(text, options) ⇒ <code>String</code>
 Removes the specified vishraams from a string.

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,9 @@ Want to play around? [![Try gurmukhi-utils on RunKit](https://badge.runkitcdn.co
 ## API
 
 ### firstLetters(line, [stripNukta], [withVishraams]) ⇒ <code>String</code>
-Generates the first letters for a given ASCII or unicode Gurmukhi string.By default, the function will transform letters with bindi to their simple equivalent,for example, zaza to jaja (ਜ਼ => ਜ).
+Generates the first letters for a given ASCII or unicode Gurmukhi string.
+By default, the function will transform letters with bindi to their simple equivalent,
+for example, zaza to jaja (ਜ਼ => ਜ).
 
 **Returns**: <code>String</code> - The first letters of each word in the provided Gurmukhi line.  
 
@@ -118,10 +120,12 @@ Checks if first char in string is part of the Gurmukhi Unicode block.
 
 **Example**  
 ```js
-isGurmukhi('ਗੁਰਮੁਖੀ') // => trueisGurmukhi('gurmuKI') // => false
+isGurmukhi('ਗੁਰਮੁਖੀ') // => true
+isGurmukhi('gurmuKI') // => false
 ```
 ### stripAccents(text) ⇒ <code>String</code>
-Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.Useful for generalising search queries.
+Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.
+Useful for generalising search queries.
 
 **Returns**: <code>String</code> - A simplified version of the provided Gurmukhi string.  
 
@@ -131,7 +135,8 @@ Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.Usef
 
 **Example**  
 ```js
-stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳstripAccents('Z^Svb') // => gKsvb
+stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳ
+stripAccents('Z^Svb') // => gKsvb
 ```
 ### stripVishraams(text, options) ⇒ <code>String</code>
 Removes the specified vishraams from a string.
@@ -171,10 +176,12 @@ Converts Gurmukhi unicode text to ASCII, used GurmukhiAkhar font.
 
 **Example**  
 ```js
-toAscii('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => hmw swieil luqi& hk prvrS ]toAscii('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => su bYiT iekMqR ]578]
+toAscii('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => hmw swieil luqi& hk prvrS ]
+toAscii('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => su bYiT iekMqR ]578]
 ```
 ### toEnglish(line) ⇒ <code>String</code>
-Transliterates a line from Unicode Gurmukhi to english.Currently supports the `,`, `;`, `.` vishraam characters.
+Transliterates a line from Unicode Gurmukhi to english.
+Currently supports the `,`, `;`, `.` vishraam characters.
 
 **Returns**: <code>String</code> - The English transliteration of the provided Gurmukhi line.  
 
@@ -201,7 +208,8 @@ Transliterates Unicode Gurmukhi text to Hindi (Devanagari script).
 
 **Example**  
 ```js
-toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥') // => कुल जन मधे मिल्यो सारग पान रे ॥toHindi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => सु बैठ इकंत्र ॥५७८॥
+toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥') // => कुल जन मधे मिल्यो सारग पान रे ॥
+toHindi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => सु बैठ इकंत्र ॥५७८॥
 ```
 ### toShahmukhi(text) ⇒ <code>String</code>
 Transliterates Unicode Gurmukhi text to the Shahmukhi script.
@@ -214,7 +222,8 @@ Transliterates Unicode Gurmukhi text to the Shahmukhi script.
 
 **Example**  
 ```js
-toShahmukhi('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => هما ساِال لُتف هک پرورش ۔۔toShahmukhi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => سُ بَےٹھ ِاکںتر ۔۔۵۷۸۔۔
+toShahmukhi('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => هما ساِال لُتف هک پرورش ۔۔
+toShahmukhi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => سُ بَےٹھ ِاکںتر ۔۔۵۷۸۔۔
 ```
 ### toUnicode(text) ⇒ <code>String</code>
 Converts ASCII text used in the GurmukhiAkhar font to Unicode.
@@ -227,7 +236,8 @@ Converts ASCII text used in the GurmukhiAkhar font to Unicode.
 
 **Example**  
 ```js
-toUnicode('kul jn mDy imil´o swrg pwn ry ]') // => ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥toUnicode('su bYiT iekMqR ]578]') // => ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥
+toUnicode('kul jn mDy imil´o swrg pwn ry ]') // => ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥
+toUnicode('su bYiT iekMqR ]578]') // => ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥
 ```
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Want to speak with us? <p>[![Slack](https://slack.shabados.com/badge.svg)](https
   * [firstLetters(line, [stripNukta], [withVishraams]) ⇒ String](#firstlettersline-stripnukta-withvishraams-%E2%87%92-string)
   * [isGurmukhi(text, [exhaustive]) ⇒ boolean](#isgurmukhitext-exhaustive-%E2%87%92-boolean)
   * [stripAccents(text) ⇒ String](#stripaccentstext-%E2%87%92-string)
+  * [stripEndings(text) ⇒ String](#stripendingstext-%E2%87%92-string)
   * [stripVishraams(text, options) ⇒ String](#stripvishraamstext-options-%E2%87%92-string)
   * [toAscii(text) ⇒ String](#toasciitext-%E2%87%92-string)
   * [toEnglish(line) ⇒ String](#toenglishline-%E2%87%92-string)
@@ -45,6 +46,7 @@ const {
   toShahmukhi,
   stripAccents,
   stripVishraams,
+  stripEndings
   isGurmukhi,
 } = require( 'gurmukhi-utils' )
 
@@ -57,7 +59,8 @@ toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ �
 toShahmukhi('ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ') // => هر هر هر گُنی
 stripAccents('ਜ਼ਫ਼ੈਸ਼ਸ') // => ਜਫੈਸਸ
 stripVishraams('sbid mrY. so mir rhY; iPir.') // => sbid mrY so mir rhY iPir
-isGurmukhi('ਗੁਰਮੁਖੀ') // t=> true
+stripEndings('ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ ॥੧॥ ਰਹਾਉ ॥') // => ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ
+isGurmukhi('ਗੁਰਮੁਖੀ') // => true
 ```
 
 Additionally, the package is available for web use via [unpkg CDN](https://unpkg.com/gurmukhi-utils).
@@ -137,6 +140,35 @@ Useful for generalising search queries.
 ```js
 stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳ
 stripAccents('Z^Svb') // => gKsvb
+```
+### stripEndings(text) ⇒ <code>String</code>
+Strips line endings from any Gurmukhi or translation string.
+Accepts both Unicode and ASCII input.
+Useful for generating accurate first letters or modifying non-Gurbani for better display.
+*Not* designed for headings or Sirlekhs.
+
+**Returns**: <code>String</code> - A ending-less version of the text.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| text | <code>String</code> | The text to stip endings from. |
+
+**Example** *(Line ending phrases)*  
+```js
+stripEndings('ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ ॥੧॥ ਰਹਾਉ ॥') // => ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ
+stripEndings('ਹੁਕਮੁ ਪਛਾਣਿ; ਤਾ ਖਸਮੈ ਮਿਲਣਾ ॥੧॥ ਰਹਾਉ ਦੂਜਾ ॥') // => ਹੁਕਮੁ ਪਛਾਣਿ; ਤਾ ਖਸਮੈ ਮਿਲਣਾ
+stripEndings('ਜਨ ਨਾਨਕ. ਗੁਰਮੁਖਿ ਜਾਤਾ ਰਾਮ ॥੪॥੬॥ ਛਕਾ ੧ ॥') // => ਜਨ ਨਾਨਕ. ਗੁਰਮੁਖਿ ਜਾਤਾ ਰਾਮ
+```
+**Example** *(English Translations)*  
+```js
+stripEndings('O Nanak, Forever And Ever True. ||1||') // => O Nanak, Forever And Ever True.
+stripEndings('lush greenery. ||1||Pause||') // => lush greenery.
+stripEndings('always I live within the Khalsa. 519') // => always I live within the Khalsa.
+stripEndings('without your reminiscence.(1) (3)') // => without your reminiscence.
+```
+**Example** *(Spanish Translations)*  
+```js
+stripEndings('ofrece su ser en sacrificio a Ti. (4-2-9)') // => ofrece su ser en sacrificio a Ti.
 ```
 ### stripVishraams(text, options) ⇒ <code>String</code>
 Removes the specified vishraams from a string.

--- a/example.js
+++ b/example.js
@@ -7,7 +7,8 @@ const {
   toEnglish,
   stripAccents,
   stripVishraams,
-  isGurmukhi
+  stripEndings,
+  isGurmukhi,
 } = require( 'gurmukhi-utils' )
 
 console.log(toUnicode( 'Koj' ))
@@ -19,4 +20,5 @@ console.log(toShahmukhi( 'ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ' ))
 console.log(toHindi( 'ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥' ))
 console.log(stripAccents('ਜ਼ਫ਼ੈਸ਼ਸ'))
 console.log(stripVishraams('sbid mrY. so mir rhY; iPir.'))
+console.log(stripEndings('ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ ॥੧॥ ਰਹਾਉ ॥'))
 console.log(isGurmukhi('ਗੁਰਮੁਖੀ'))

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ export function firstLetters(text: string, stripNukta?: boolean = true, withVish
 export function isGurmukhi(text: string, exhaustive?: boolean): boolean
 
 export function stripAccents(text: string): string
+
 interface StripVishraamsOptions {
   heavy?: boolean;
   medium?: boolean;
@@ -20,3 +21,5 @@ interface StripVishraamsOptions {
 }
 
 export function stripVishraams(text: string, options?: StripVishraamsOptions): string
+
+export function stripEndings(text: string): string

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const toHindi = require( './lib/toHindi' )
 const isGurmukhi = require( './lib/isGurmukhi' )
 const stripAccents = require( './lib/stripAccents' )
 const stripVishraams = require( './lib/stripVishraams' )
+const stripEndings = require( './lib/stripEndings' )
 
 module.exports = {
   toAscii,
@@ -18,4 +19,5 @@ module.exports = {
   isGurmukhi,
   stripAccents,
   stripVishraams,
+  stripEndings,
 }

--- a/lib/regex-utils.js
+++ b/lib/regex-utils.js
@@ -1,0 +1,7 @@
+const escapeStringRegexp = require( 'escape-string-regexp' )
+
+const getRegexClass = characters => `[${characters.map( escapeStringRegexp ).join( '' )}]`
+
+const getRegexGroup = characters => `(${characters.map( escapeStringRegexp ).join( '|' )})`
+
+module.exports = { getRegexClass, getRegexGroup }

--- a/lib/stripEndings.js
+++ b/lib/stripEndings.js
@@ -1,0 +1,51 @@
+const toUnicode = require( './toUnicode' )
+const toAscii = require( './toAscii' )
+const { getRegexClass, getRegexGroup } = require( './regex-utils' )
+
+// Line endings in both ASCII, Unicode, and English
+const endingClass = getRegexClass( [ '।', '॥', ']', '[', '|' ] )
+// Sometimes translation line endings begin with these characters, before numbers
+const optionalEndingClass = getRegexClass( [ '(' ] )
+// Remove any broken endings
+const brokenEndingClass = getRegexGroup( [ '()' ] )
+
+// All numbers in ASCII, Unicode
+const numbers = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ].map( i => i.toString() )
+const numberClass = getRegexClass( [ ...numbers, ...numbers.map( toUnicode ) ] )
+
+// Rahao in English, ASCII, Unicode
+const pauseGroup = getRegexGroup( [ 'ਰਹਾਉ', toAscii( 'ਰਹਾਉ' ), 'Pause' ] )
+
+const matchers = [
+  // Endings followed by any number => match the rest of the line
+  ` ?(${endingClass}|${optionalEndingClass}?)${numberClass}.*`,
+  // || Rahao || style endings
+  ` ?${endingClass} ?${pauseGroup} ?${endingClass}`,
+  // Clean up any lingering ending characters
+  brokenEndingClass,
+  endingClass,
+].map( exp => new RegExp( exp, 'g' ) )
+
+
+/**
+ * Strips line endings from any Gurmukhi or translation string.
+ * Accepts both Unicode and ASCII input.
+ * Useful for generating accurate first letters or modifying non-Gurbani for better display.
+ * *Not* designed for headings or Sirlekhs.
+ * @param {String} text The text to stip endings from.
+ * @return {String} A ending-less version of the text.
+ * @example <caption>Line ending phrases</caption>
+ * stripEndings('ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ ॥੧॥ ਰਹਾਉ ॥') // => ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ
+ * stripEndings('ਹੁਕਮੁ ਪਛਾਣਿ; ਤਾ ਖਸਮੈ ਮਿਲਣਾ ॥੧॥ ਰਹਾਉ ਦੂਜਾ ॥') // => ਹੁਕਮੁ ਪਛਾਣਿ; ਤਾ ਖਸਮੈ ਮਿਲਣਾ
+ * stripEndings('ਜਨ ਨਾਨਕ. ਗੁਰਮੁਖਿ ਜਾਤਾ ਰਾਮ ॥੪॥੬॥ ਛਕਾ ੧ ॥') // => ਜਨ ਨਾਨਕ. ਗੁਰਮੁਖਿ ਜਾਤਾ ਰਾਮ
+ * @example <caption>English Translations</caption>
+ * stripEndings('O Nanak, Forever And Ever True. ||1||') // => O Nanak, Forever And Ever True.
+ * stripEndings('lush greenery. ||1||Pause||') // => lush greenery.
+ * stripEndings('always I live within the Khalsa. 519') // => always I live within the Khalsa.
+ * stripEndings('without your reminiscence.(1) (3)') // => without your reminiscence.
+ * @example <caption>Spanish Translations</caption>
+ * stripEndings('ofrece su ser en sacrificio a Ti. (4-2-9)') // => ofrece su ser en sacrificio a Ti.
+ */
+const stripEndings = text => matchers.reduce( ( text, exp ) => text.replace( exp, '' ), text ).trimRight()
+
+module.exports = stripEndings

--- a/lib/stripVishraams.js
+++ b/lib/stripVishraams.js
@@ -1,6 +1,7 @@
 const vishraams = require( './vishraams.json' )
+const { getRegexClass } = require( './regex-utils' )
 
-const vishraamRegExp = vishraams => new RegExp( `[${vishraams.join( '' )}]`, 'g' )
+const vishraamRegExp = vishraams => new RegExp( getRegexClass( vishraams ), 'g' )
 
 /**
  * Removes the specified vishraams from a string.

--- a/test/stripEndings.spec.js
+++ b/test/stripEndings.spec.js
@@ -1,0 +1,77 @@
+const { expect } = require( 'chai' )
+
+const { stripEndings, toAscii } = require( '..' )
+
+const gurmukhiPassages = [
+  [ 'ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ ॥੧॥ ਰਹਾਉ ॥', 'ਸੋ ਘਰੁ ਰਾਖੁ; ਵਡਾਈ ਤੋਇ' ],
+  [ 'ਹੁਕਮੁ ਪਛਾਣਿ; ਤਾ ਖਸਮੈ ਮਿਲਣਾ ॥੧॥ ਰਹਾਉ ਦੂਜਾ ॥', 'ਹੁਕਮੁ ਪਛਾਣਿ; ਤਾ ਖਸਮੈ ਮਿਲਣਾ' ],
+  [ 'ਨਾਮੁ ਅਧਾਰੁ ਦੀਜੈ. ਨਾਨਕ ਕਉ; ਆਨਦ ਸੂਖ ਘਨੇਰੈ ॥੨॥੧੨॥ ਛਕੇ ੨ ॥', 'ਨਾਮੁ ਅਧਾਰੁ ਦੀਜੈ. ਨਾਨਕ ਕਉ; ਆਨਦ ਸੂਖ ਘਨੇਰੈ' ],
+  [ 'ਜਪਿ ਜਪਿ ਨਾਮੁ ਜੀਵਾ ਤੇਰੀ ਬਾਣੀ; ਨਾਨਕ ਦਾਸ ਬਲਿਹਾਰੇ ॥੨॥੧੮॥ ਛਕੇ ੩ ॥', 'ਜਪਿ ਜਪਿ ਨਾਮੁ ਜੀਵਾ ਤੇਰੀ ਬਾਣੀ; ਨਾਨਕ ਦਾਸ ਬਲਿਹਾਰੇ' ],
+  [ 'ਸਹਸ ਸਿਆਣਪ ਨਹ ਮਿਲੈ, ਮੇਰੀ ਜਿੰਦੁੜੀਏ; ਜਨ ਨਾਨਕ. ਗੁਰਮੁਖਿ ਜਾਤਾ ਰਾਮ ॥੪॥੬॥ ਛਕਾ ੧ ॥', 'ਸਹਸ ਸਿਆਣਪ ਨਹ ਮਿਲੈ, ਮੇਰੀ ਜਿੰਦੁੜੀਏ; ਜਨ ਨਾਨਕ. ਗੁਰਮੁਖਿ ਜਾਤਾ ਰਾਮ' ],
+  [ 'ਆਇ ਮਿਲੁ ਗੁਰਸਿਖ. ਆਇ ਮਿਲੁ; ਤੂ ਮੇਰੇ ਗੁਰੂ ਕੇ ਪਿਆਰੇ ॥ ਰਹਾਉ ॥', 'ਆਇ ਮਿਲੁ ਗੁਰਸਿਖ. ਆਇ ਮਿਲੁ; ਤੂ ਮੇਰੇ ਗੁਰੂ ਕੇ ਪਿਆਰੇ' ],
+  [ 'ਜਹਾ ਤੇ ਉਪਜਿਆ; ਫਿਰਿ ਤਹਾ ਸਮਾਵੈ ।੪੯।੧। ਇਕੁ ।', 'ਜਹਾ ਤੇ ਉਪਜਿਆ; ਫਿਰਿ ਤਹਾ ਸਮਾਵੈ' ],
+  [ 'ਇਸੁ ਬੰਦੇ ਸਿਰਿ ਜੁਲਮੁ ਹੋਤ ਹੈ; ਜਮੁ. ਨਹੀ ਹਟੈ ਗੁਸਾਈ ॥੪॥੯॥ ਦੁਤੁਕੇ', 'ਇਸੁ ਬੰਦੇ ਸਿਰਿ ਜੁਲਮੁ ਹੋਤ ਹੈ; ਜਮੁ. ਨਹੀ ਹਟੈ ਗੁਸਾਈ' ],
+  [ 'ਨਾਨਕ. ਮਨਿ ਤਨਿ ਚਾਉ ਏਹੁ; ਨਿਤ ਪ੍ਰਭ ਕਉ ਲੋੜੇ ॥੨੧॥੧॥ ਸੁਧੁ ਕੀਚੇ', 'ਨਾਨਕ. ਮਨਿ ਤਨਿ ਚਾਉ ਏਹੁ; ਨਿਤ ਪ੍ਰਭ ਕਉ ਲੋੜੇ' ],
+  [
+    'ਤਿਸੀ ਪ੍ਰਕਾਰ ਹੀ ਗੁਰੂ ਸੇਵਾ ਤਥਾ ਨਾਮ ਵਿਖੇ ਪਿੰਡ ਸਰੀਰ ਦੇ ਪਰਚੇ ਬਿਨਾਂ ਜੋ ਸਿੱਖਾਂ ਦੀ ਭਿਛ੍ਯਾ ਖਾਵੇ ਅਰਥਾਤ ਓਨਾਂ ਦੀ ਕਾਰ ਭੇਟ ਦਾ ਆਯਾ ਪਦਾਰਥ ਖਾਏ ਤਾਂ ਅੰਤ ਕਾਲ ਨੂੰ ਔਕੜ ਹੋਯਾ ਕਰਦੀ ਹੈ, ਤੇ ਜਮ ਲੋਕ ਨਰਕ ਨੂੰ ਜਾਣਾ ਪੈਂਦਾ ਹੈ ॥੫੧੭॥ ਪੜ੍ਹੋ ਵੀਚਾਰ ਕਬਿੱਤ ੫੦੬',
+    'ਤਿਸੀ ਪ੍ਰਕਾਰ ਹੀ ਗੁਰੂ ਸੇਵਾ ਤਥਾ ਨਾਮ ਵਿਖੇ ਪਿੰਡ ਸਰੀਰ ਦੇ ਪਰਚੇ ਬਿਨਾਂ ਜੋ ਸਿੱਖਾਂ ਦੀ ਭਿਛ੍ਯਾ ਖਾਵੇ ਅਰਥਾਤ ਓਨਾਂ ਦੀ ਕਾਰ ਭੇਟ ਦਾ ਆਯਾ ਪਦਾਰਥ ਖਾਏ ਤਾਂ ਅੰਤ ਕਾਲ ਨੂੰ ਔਕੜ ਹੋਯਾ ਕਰਦੀ ਹੈ, ਤੇ ਜਮ ਲੋਕ ਨਰਕ ਨੂੰ ਜਾਣਾ ਪੈਂਦਾ ਹੈ',
+  ],
+  [ 'ਸ੍ਰੀ ਗੁਰੂ ਜੀ ਕਹਤੇ ਹੈਂ: ਜੋ ਰਾਤ ਦਿਨ ਨਾਮ ਜਪਤੇ ਹੈਂ ਐਸੇ ਗੁਰੋਂ ਕੇ ਮੁਖ ਸੇ ਵਾਹੁ ਵਾਹੁ ਬਾਣੀ ਪ੍ਰਾਪਤ ਹੋਤੀ ਹੈ॥੧॥', 'ਸ੍ਰੀ ਗੁਰੂ ਜੀ ਕਹਤੇ ਹੈਂ: ਜੋ ਰਾਤ ਦਿਨ ਨਾਮ ਜਪਤੇ ਹੈਂ ਐਸੇ ਗੁਰੋਂ ਕੇ ਮੁਖ ਸੇ ਵਾਹੁ ਵਾਹੁ ਬਾਣੀ ਪ੍ਰਾਪਤ ਹੋਤੀ ਹੈ' ],
+  [ 'ਹੇ ਨਾਨਕ! ਜੋ ਮਨੁੱਖ ਗੁਰੂ ਦੇ ਹੁਕਮ ਵਿਚ ਤੁਰਦਾ ਹੈ ਉਸ ਨੂੰ ਸਿਫ਼ਤ-ਸਾਲਾਹ ਦੀ ਦਾਤ ਮਿਲਦੀ ਹੈ, ਉਹ ਹਰ ਵੇਲੇ ਪ੍ਰਭੂ ਦਾ ਨਾਮ ਜਪਦਾ ਹੈ ॥੧॥', 'ਹੇ ਨਾਨਕ! ਜੋ ਮਨੁੱਖ ਗੁਰੂ ਦੇ ਹੁਕਮ ਵਿਚ ਤੁਰਦਾ ਹੈ ਉਸ ਨੂੰ ਸਿਫ਼ਤ-ਸਾਲਾਹ ਦੀ ਦਾਤ ਮਿਲਦੀ ਹੈ, ਉਹ ਹਰ ਵੇਲੇ ਪ੍ਰਭੂ ਦਾ ਨਾਮ ਜਪਦਾ ਹੈ' ],
+  [ 'ਸ੍ਰੀ ਗੁਰੂ ਜੀ ਕਹਤੇ ਹੈਂ: ਸੋ ਹਰਿ ਨਾਮ ਕਾ ਜੋ ਰਾਤ ਦਿਨ ਭਜਨ ਕਰਤਾ ਹੈ ਤਿਸ ਕੇ ਸਭ ਕਾਮ ਸਫਲ ਹੋਤੇ ਹੈਂ ਅਰਥਾਤ ਪੂਰਨ ਕਾਮ ਹੋਤਾ ਹੈ॥੨੦', 'ਸ੍ਰੀ ਗੁਰੂ ਜੀ ਕਹਤੇ ਹੈਂ: ਸੋ ਹਰਿ ਨਾਮ ਕਾ ਜੋ ਰਾਤ ਦਿਨ ਭਜਨ ਕਰਤਾ ਹੈ ਤਿਸ ਕੇ ਸਭ ਕਾਮ ਸਫਲ ਹੋਤੇ ਹੈਂ ਅਰਥਾਤ ਪੂਰਨ ਕਾਮ ਹੋਤਾ ਹੈ' ],
+  [ 'so dru rwgu Awsw mhlw 1 ]', 'so dru rwgu Awsw mhlw' ],
+]
+
+const asciiPassages = gurmukhiPassages.map( ( [ input, output ] ) => [
+  toAscii( input ),
+  toAscii( output ),
+] )
+
+const translationPassages = [
+  [ 'True Here And Now. O Nanak, Forever And Ever True. ||1||', 'True Here And Now. O Nanak, Forever And Ever True.' ],
+  [
+    "By Guru's Grace, the supreme status is obtained, and the dry wood blossoms forth again in lush greenery. ||1||Pause||",
+    "By Guru's Grace, the supreme status is obtained, and the dry wood blossoms forth again in lush greenery.",
+  ],
+  [ 'He puts on various ornaments and many decorations, but it is like dressing a corpse. ||Pause||', 'He puts on various ornaments and many decorations, but it is like dressing a corpse.' ],
+  [ 'Servant Nanak is devoted, dedicated, forever a sacrifice to You, Lord. Your Expanse has no limit, no boundary. ||4||5||', 'Servant Nanak is devoted, dedicated, forever a sacrifice to You, Lord. Your Expanse has no limit, no boundary.' ],
+  [ 'lifts him to the divine level of supreme consciousness. (103', 'lifts him to the divine level of supreme consciousness.' ],
+  [ 'What is the purpose of my life (it became worthless) without your reminiscence.(1) (3)', 'What is the purpose of my life (it became worthless) without your reminiscence.' ],
+  [
+    'Just one of his (blessed) looks, that prolongs life instantly, is enough for me." (2) (2)\nSometimes, he acts like a mystic, sometimes like a meditator, and other times like a carefree recluse;\nHe is our pilot steering our way; he operates in numerous different postures. (2) (3)',
+    'Just one of his (blessed) looks, that prolongs life instantly, is enough for me."\nSometimes, he acts like a mystic, sometimes like a meditator, and other times like a carefree recluse;\nHe is our pilot steering our way; he operates in numerous different postures.',
+  ],
+  [ 'always I live within the Khalsa. 519', 'always I live within the Khalsa.' ],
+  [ 'Salutation to Thee O Abodeless Lord! 5', 'Salutation to Thee O Abodeless Lord!' ],
+  [ 'Thy Virtues like Generosity are countless.91', 'Thy Virtues like Generosity are countless.' ],
+  [ 'It was Bikrami Samvat 1753', 'It was Bikrami Samvat' ],
+  [ 'He also forgot the unmanifested Brahmin and said this583', 'He also forgot the unmanifested Brahmin and said this' ],
+  [ 'Somewhere Thou art manifesting the mode of Tamas in a kingly mood!  16. 106', 'Somewhere Thou art manifesting the mode of Tamas in a kingly mood!' ],
+  [ 'He is Without blemish and stain and be visualised as consisting of Indestructible Glory .16.176', 'He is Without blemish and stain and be visualised as consisting of Indestructible Glory .' ],
+  [ 'He is the Sustainer of all the beings and creatures!9. 239', 'He is the Sustainer of all the beings and creatures!' ],
+  [ 'Thee as the Abode of Dharma.2.254', 'Thee as the Abode of Dharma.' ],
+  [ 'He said to the warriors fighting near him,1069', 'He said to the warriors fighting near him,' ],
+  [ 'Noche y día oh, dice Nanak, quien medite y vibre en el Nombre del Señor, ve cómo todos sus esfuerzos dan fruto. (20)', 'Noche y día oh, dice Nanak, quien medite y vibre en el Nombre del Señor, ve cómo todos sus esfuerzos dan fruto.' ],
+  [ 'A tal ser el Señor lo encuentra y nunca más lo abandona, ya que lo inmerge en Su Paz Maravillosa.  ()1', 'A tal ser el Señor lo encuentra y nunca más lo abandona, ya que lo inmerge en Su Paz Maravillosa.' ],
+  [
+    'Misteriosa es la manera de los verdaderos Discípulos, porque no solamente escuchan la Instrucción del Guru, sino que se encuentran totalmente sobrellevados por ella. 25',
+    'Misteriosa es la manera de los verdaderos Discípulos, porque no solamente escuchan la Instrucción del Guru, sino que se encuentran totalmente sobrellevados por ella.',
+  ],
+  [
+    'El mundo ha nacido para morir y es siempre destruido, una, otra, y otra vez; solamente uno se vuelve Eterno aferrándose a los Pies del Guru. (4‑6‑13',
+    'El mundo ha nacido para morir y es siempre destruido, una, otra, y otra vez; solamente uno se vuelve Eterno aferrándose a los Pies del Guru.',
+  ],
+  [ 'Toda la Maya es Tu Deleite. Nanak, Tu Esclavo, ofrece su ser en sacrificio a Ti. (4-2-9)', 'Toda la Maya es Tu Deleite. Nanak, Tu Esclavo, ofrece su ser en sacrificio a Ti.' ],
+  [ 'ese hombre ha recibido la Aprobación de Dios.  (4-40-47)', 'ese hombre ha recibido la Aprobación de Dios.' ],
+]
+
+const passages = [
+  ...gurmukhiPassages,
+  ...asciiPassages,
+  ...translationPassages,
+]
+
+describe( 'stripEndings()', () => passages.map( ( [ line, result ] ) => it(
+  `should transform '${line}' to '${result}'`,
+  () => expect( stripEndings( line ) ).to.equal( result ),
+) ) )


### PR DESCRIPTION
### Summary of PR
Adds `stripEndings()`. This removes line and page numbers, as well as rahao and other end of line breakers. Handles ascii, unicode, and english + spanish translations.

Please check the test cases to review that this is indeed the behaviour we are looking for.

### Tests for unexpected behavior
- The test suite

### Time spent on PR
2 hours

### Linked issues
Closes #25 
Closes #138

### Reviewers
@bhajneet 