### PR TITLE
feat(firstLetters): simplify interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Want to speak with us? <p>[![Slack](https://slack.shabados.com/badge.svg)](https
 
 - [Usage](#usage)
 - [API](#api)
-  * [firstLetters(line, [stripNukta], [withVishraams]) ⇒ String](#firstlettersline-stripnukta-withvishraams-%E2%87%92-string)
+  * [firstLetters(line) ⇒ String](#firstlettersline-%E2%87%92-string)
   * [isGurmukhi(text, [exhaustive]) ⇒ boolean](#isgurmukhitext-exhaustive-%E2%87%92-boolean)
   * [stripAccents(text) ⇒ String](#stripaccentstext-%E2%87%92-string)
   * [stripVishraams(text, options) ⇒ String](#stripvishraamstext-options-%E2%87%92-string)
@@ -70,41 +70,23 @@ Want to play around? [![Try gurmukhi-utils on RunKit](https://badge.runkitcdn.co
 
 ## API
 
-### firstLetters(line, [stripNukta], [withVishraams]) ⇒ <code>String</code>
-Generates the first letters for a given ASCII or unicode Gurmukhi string.By default, the function will transform letters with bindi to their simple equivalent,for example, zaza to jaja (ਜ਼ => ਜ).
+### firstLetters(line) ⇒ <code>String</code>
+Generates the first letters for a given ASCII or unicode Gurmukhi string.
+Includes any end-word vishraams, and line-end characters.
 
 **Returns**: <code>String</code> - The first letters of each word in the provided Gurmukhi line.  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| line | <code>String</code> |  | The line to generate the first letters for. |
-| [stripNukta] | <code>Boolean</code> | <code>true</code> | If `true`, replaces letters pair bindi (such as ਜ਼) with their equivalent without the bindi (ਜ). Also replaces open oora with closed oora. |
-| [withVishraams] | <code>Boolean</code> | <code>false</code> | Keeps the vishraam characters at the end of each word. |
+| Param | Type | Description |
+| --- | --- | --- |
+| line | <code>String</code> | The line to generate the first letters for. |
 
-**Example** *(Unicode first letters no pair bindi/nukta)*  
+**Example** *(Unicode first letters)*  
 ```js
-firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ') // => ਗਹਹਨਬਜਹਗ
+firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ॥
 ```
-**Example** *(Unicode first letters with pair bindi/nukta)*  
+**Example** *(ASCII first letters)*  
 ```js
-firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', false) // => ਗ਼ਹਹਨਬਜ਼ਹਗ
-```
-**Example** *(Unicode first letters with vishraams)*  
-```js
-firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ
-```
-**Example** *(ASCII first letters no pair bindi/nukta)*  
-```js
-firstLetters('ijs no ik®pw krih iqin nwmu rqnu pwieAw ]') // => jnkkqnrp
-firstLetters('iZir&qym sMdUk drIXw AmIk ]') // => gsdA
-```
-**Example** *(ASCII first letters with pair bindi/nukta)*  
-```js
-firstLetters('iZir&qym sMdUk* drIXw AmIk* ]', false) // => Zsda
-```
-**Example** *(ASCII first letters with vishraams)*  
-```js
-firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', true, true) // => sm.smr;P.mn,dv
+firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]') => //sm.smr;P.mn,dv]
 ```
 ### isGurmukhi(text, [exhaustive]) ⇒ <code>boolean</code>
 Checks if first char in string is part of the Gurmukhi Unicode block.
@@ -118,10 +100,12 @@ Checks if first char in string is part of the Gurmukhi Unicode block.
 
 **Example**  
 ```js
-isGurmukhi('ਗੁਰਮੁਖੀ') // => trueisGurmukhi('gurmuKI') // => false
+isGurmukhi('ਗੁਰਮੁਖੀ') // => true
+isGurmukhi('gurmuKI') // => false
 ```
 ### stripAccents(text) ⇒ <code>String</code>
-Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.Useful for generalising search queries.
+Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.
+Useful for generalising search queries.
 
 **Returns**: <code>String</code> - A simplified version of the provided Gurmukhi string.  
 
@@ -131,7 +115,8 @@ Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.Usef
 
 **Example**  
 ```js
-stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳstripAccents('Z^Svb') // => gKsvb
+stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳ
+stripAccents('Z^Svb') // => gKsvb
 ```
 ### stripVishraams(text, options) ⇒ <code>String</code>
 Removes the specified vishraams from a string.
@@ -171,10 +156,12 @@ Converts Gurmukhi unicode text to ASCII, used GurmukhiAkhar font.
 
 **Example**  
 ```js
-toAscii('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => hmw swieil luqi& hk prvrS ]toAscii('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => su bYiT iekMqR ]578]
+toAscii('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => hmw swieil luqi& hk prvrS ]
+toAscii('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => su bYiT iekMqR ]578]
 ```
 ### toEnglish(line) ⇒ <code>String</code>
-Transliterates a line from Unicode Gurmukhi to english.Currently supports the `,`, `;`, `.` vishraam characters.
+Transliterates a line from Unicode Gurmukhi to english.
+Currently supports the `,`, `;`, `.` vishraam characters.
 
 **Returns**: <code>String</code> - The English transliteration of the provided Gurmukhi line.  
 
@@ -201,7 +188,8 @@ Transliterates Unicode Gurmukhi text to Hindi (Devanagari script).
 
 **Example**  
 ```js
-toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥') // => कुल जन मधे मिल्यो सारग पान रे ॥toHindi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => सु बैठ इकंत्र ॥५७८॥
+toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥') // => कुल जन मधे मिल्यो सारग पान रे ॥
+toHindi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => सु बैठ इकंत्र ॥५७८॥
 ```
 ### toShahmukhi(text) ⇒ <code>String</code>
 Transliterates Unicode Gurmukhi text to the Shahmukhi script.
@@ -214,7 +202,8 @@ Transliterates Unicode Gurmukhi text to the Shahmukhi script.
 
 **Example**  
 ```js
-toShahmukhi('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => هما ساِال لُتف هک پرورش ۔۔toShahmukhi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => سُ بَےٹھ ِاکںتر ۔۔۵۷۸۔۔
+toShahmukhi('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => هما ساِال لُتف هک پرورش ۔۔
+toShahmukhi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => سُ بَےٹھ ِاکںتر ۔۔۵۷۸۔۔
 ```
 ### toUnicode(text) ⇒ <code>String</code>
 Converts ASCII text used in the GurmukhiAkhar font to Unicode.
@@ -227,7 +216,8 @@ Converts ASCII text used in the GurmukhiAkhar font to Unicode.
 
 **Example**  
 ```js
-toUnicode('kul jn mDy imil´o swrg pwn ry ]') // => ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥toUnicode('su bYiT iekMqR ]578]') // => ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥
+toUnicode('kul jn mDy imil´o swrg pwn ry ]') // => ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥
+toUnicode('su bYiT iekMqR ]578]') // => ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥
 ```
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Want to speak with us? <p>[![Slack](https://slack.shabados.com/badge.svg)](https
 
 - [Usage](#usage)
 - [API](#api)
-  * [firstLetters(line, [stripNukta], [withVishraams]) ⇒ String](#firstlettersline-stripnukta-withvishraams-%E2%87%92-string)
+  * [firstLetters(line) ⇒ String](#firstlettersline-%E2%87%92-string)
   * [isGurmukhi(text, [exhaustive]) ⇒ boolean](#isgurmukhitext-exhaustive-%E2%87%92-boolean)
   * [stripAccents(text) ⇒ String](#stripaccentstext-%E2%87%92-string)
   * [stripVishraams(text, options) ⇒ String](#stripvishraamstext-options-%E2%87%92-string)
@@ -70,41 +70,23 @@ Want to play around? [![Try gurmukhi-utils on RunKit](https://badge.runkitcdn.co
 
 ## API
 
-### firstLetters(line, [stripNukta], [withVishraams]) ⇒ <code>String</code>
-Generates the first letters for a given ASCII or unicode Gurmukhi string.By default, the function will transform letters with bindi to their simple equivalent,for example, zaza to jaja (ਜ਼ => ਜ).
+### firstLetters(line) ⇒ <code>String</code>
+Generates the first letters for a given ASCII or unicode Gurmukhi string.
+Includes any end-word vishraams, and line-end characters.
 
 **Returns**: <code>String</code> - The first letters of each word in the provided Gurmukhi line.  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| line | <code>String</code> |  | The line to generate the first letters for. |
-| [stripNukta] | <code>Boolean</code> | <code>true</code> | If `true`, replaces letters pair bindi (such as ਜ਼) with their equivalent without the bindi (ਜ). Also replaces open oora with closed oora. |
-| [withVishraams] | <code>Boolean</code> | <code>false</code> | Keeps the vishraam characters at the end of each word. |
+| Param | Type | Description |
+| --- | --- | --- |
+| line | <code>String</code> | The line to generate the first letters for. |
 
-**Example** *(Unicode first letters no pair bindi/nukta)*  
+**Example** *(Unicode first letters)*  
 ```js
-firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ') // => ਗਹਹਨਬਜਹਗ
+firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ॥
 ```
-**Example** *(Unicode first letters with pair bindi/nukta)*  
+**Example** *(ASCII first letters)*  
 ```js
-firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', false) // => ਗ਼ਹਹਨਬਜ਼ਹਗ
-```
-**Example** *(Unicode first letters with vishraams)*  
-```js
-firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ
-```
-**Example** *(ASCII first letters no pair bindi/nukta)*  
-```js
-firstLetters('ijs no ik®pw krih iqin nwmu rqnu pwieAw ]') // => jnkkqnrp
-firstLetters('iZir&qym sMdUk drIXw AmIk ]') // => gsdA
-```
-**Example** *(ASCII first letters with pair bindi/nukta)*  
-```js
-firstLetters('iZir&qym sMdUk* drIXw AmIk* ]', false) // => Zsda
-```
-**Example** *(ASCII first letters with vishraams)*  
-```js
-firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', true, true) // => sm.smr;P.mn,dv
+firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]') => //sm.smr;P.mn,dv]
 ```
 ### isGurmukhi(text, [exhaustive]) ⇒ <code>boolean</code>
 Checks if first char in string is part of the Gurmukhi Unicode block.
@@ -118,10 +100,12 @@ Checks if first char in string is part of the Gurmukhi Unicode block.
 
 **Example**  
 ```js
-isGurmukhi('ਗੁਰਮੁਖੀ') // => trueisGurmukhi('gurmuKI') // => false
+isGurmukhi('ਗੁਰਮੁਖੀ') // => true
+isGurmukhi('gurmuKI') // => false
 ```
 ### stripAccents(text) ⇒ <code>String</code>
-Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.Useful for generalising search queries.
+Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.
+Useful for generalising search queries.
 
 **Returns**: <code>String</code> - A simplified version of the provided Gurmukhi string.  
 
@@ -131,7 +115,8 @@ Removes accents from ASCII/Unicode Gumrukhi letters with their base letter.Usef
 
 **Example**  
 ```js
-stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳstripAccents('Z^Svb') // => gKsvb
+stripAccents('ਜ਼ਫ਼ੈਸ਼ਸਓ') // => ਜਫੈਸਸੳ
+stripAccents('Z^Svb') // => gKsvb
 ```
 ### stripVishraams(text, options) ⇒ <code>String</code>
 Removes the specified vishraams from a string.
@@ -171,10 +156,12 @@ Converts Gurmukhi unicode text to ASCII, used GurmukhiAkhar font.
 
 **Example**  
 ```js
-toAscii('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => hmw swieil luqi& hk prvrS ]toAscii('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => su bYiT iekMqR ]578]
+toAscii('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => hmw swieil luqi& hk prvrS ]
+toAscii('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => su bYiT iekMqR ]578]
 ```
 ### toEnglish(line) ⇒ <code>String</code>
-Transliterates a line from Unicode Gurmukhi to english.Currently supports the `,`, `;`, `.` vishraam characters.
+Transliterates a line from Unicode Gurmukhi to english.
+Currently supports the `,`, `;`, `.` vishraam characters.
 
 **Returns**: <code>String</code> - The English transliteration of the provided Gurmukhi line.  
 
@@ -201,7 +188,8 @@ Transliterates Unicode Gurmukhi text to Hindi (Devanagari script).
 
 **Example**  
 ```js
-toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥') // => कुल जन मधे मिल्यो सारग पान रे ॥toHindi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => सु बैठ इकंत्र ॥५७८॥
+toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥') // => कुल जन मधे मिल्यो सारग पान रे ॥
+toHindi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => सु बैठ इकंत्र ॥५७८॥
 ```
 ### toShahmukhi(text) ⇒ <code>String</code>
 Transliterates Unicode Gurmukhi text to the Shahmukhi script.
@@ -214,7 +202,8 @@ Transliterates Unicode Gurmukhi text to the Shahmukhi script.
 
 **Example**  
 ```js
-toShahmukhi('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => هما ساِال لُتف هک پرورش ۔۔toShahmukhi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => سُ بَےٹھ ِاکںتر ۔۔۵۷۸۔۔
+toShahmukhi('ਹਮਾ ਸਾਇਲਿ ਲੁਤਫ਼ਿ ਹਕ ਪਰਵਰਸ਼ ॥') // => هما ساِال لُتف هک پرورش ۔۔
+toShahmukhi('ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥') // => سُ بَےٹھ ِاکںتر ۔۔۵۷۸۔۔
 ```
 ### toUnicode(text) ⇒ <code>String</code>
 Converts ASCII text used in the GurmukhiAkhar font to Unicode.
@@ -227,7 +216,8 @@ Converts ASCII text used in the GurmukhiAkhar font to Unicode.
 
 **Example**  
 ```js
-toUnicode('kul jn mDy imil´o swrg pwn ry ]') // => ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥toUnicode('su bYiT iekMqR ]578]') // => ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥
+toUnicode('kul jn mDy imil´o swrg pwn ry ]') // => ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥
+toUnicode('su bYiT iekMqR ]578]') // => ਸੁ ਬੈਠਿ ਇਕੰਤ੍ਰ ॥੫੭੮॥
 ```
 
 ## Contributing

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export function toHindi(text: string): string
 
 export function toShamukhi(text: string): string
 
-export function firstLetters(text: string, stripNukta?: boolean = true, withVishraams?: boolean): string
+export function firstLetters(text: string): string
 
 export function isGurmukhi(text: string, exhaustive?: boolean): boolean
 

--- a/lib/firstLetters.js
+++ b/lib/firstLetters.js
@@ -1,62 +1,19 @@
 const vishraams = Object.values( require( './vishraams.json' ) )
 
-// The mappings from the letter-variations to simple Gurmukhi letters in ASCII.
-const asciiBaseLetterMap = {
-  E: 'a', // Open oora -> oora
-  S: 's', // Shasha -> sasa
-  z: 'j', // zaza -> jaja
-  Z: 'g', // gaga pair bindi -> gaga
-  L: 'l', // lala pair bindi -> lala
-  '^': 'K', // Khakha pair bindi -> khakha
-  '&': 'P', // Fafa pair bindi -> Fafa
-}
-
-const unicodeBaseLetterMap = {
-  ਓ: 'ੳ', // Open oora -> oora
-  ਸ਼: 'ਸ', // Shasha -> sasa
-  ਜ਼: 'ਜ', // zaza -> jaja
-  ਗ਼: 'ਗ', // gaga pair bindi -> gaga
-  ਲ਼: 'ਲ', // lala pair bindi -> lala
-  ਖ਼: 'ਖ', // Khakha pair bindi -> khakha
-  ਫ਼: 'ਫ', // Fafa pair bindi -> Fafa
-}
-
-// Specifies the line terminator characters for both ASCII and unicode Gurmukhi
-const lineTerminators = new Set( [ '।', '॥', ']', '[' ] )
-
-// Combine the base letter maps
-const combinedBaseLetterMap = { ...asciiBaseLetterMap, ...unicodeBaseLetterMap }
-
 /**
  * Generates the first letters for a given ASCII or unicode Gurmukhi string.
- * By default, the function will transform letters with bindi to their simple equivalent,
- * for example, zaza to jaja (ਜ਼ => ਜ).
+ * Includes any end-word vishraams, and line-end characters.
+ *
  * @param {String} line The line to generate the first letters for.
- * @param {Boolean} [stripNukta=true] If `true`, replaces letters pair bindi (such as ਜ਼)
- * with their equivalent without the bindi (ਜ). Also replaces open oora with closed oora.
- * @param {Boolean} [withVishraams=false] Keeps the vishraam characters at the end of each word.
  * @returns {String} The first letters of each word in the provided Gurmukhi line.
  *
- * @example <caption>Unicode first letters no pair bindi/nukta</caption>
- * firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ') // => ਗਹਹਨਬਜਹਗ
+ * @example <caption>Unicode first letters</caption>
+ * firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ॥
  *
- * @example <caption>Unicode first letters with pair bindi/nukta</caption>
- * firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', false) // => ਗ਼ਹਹਨਬਜ਼ਹਗ
- *
- * @example <caption>Unicode first letters with vishraams</caption>
- * firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ
- *
- * @example <caption>ASCII first letters no pair bindi/nukta</caption>
- * firstLetters('ijs no ik®pw krih iqin nwmu rqnu pwieAw ]') // => jnkkqnrp
- * firstLetters('iZir&qym sMdUk drIXw AmIk ]') // => gsdA
- *
- * @example <caption>ASCII first letters with pair bindi/nukta</caption>
- * firstLetters('iZir&qym sMdUk* drIXw AmIk* ]', false) // => Zsda
- *
- * @example <caption>ASCII first letters with vishraams</caption>
- * firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', true, true) // => sm.smr;P.mn,dv
+ * @example <caption>ASCII first letters</caption>
+ * firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]') => //sm.smr;P.mn,dv]
  */
-const firstLetters = ( line, stripNukta = true, withVishraams ) => line
+const firstLetters = line => line
   // Split into words
   .split( ' ' )
   // Grab correct letter of each word
@@ -64,17 +21,14 @@ const firstLetters = ( line, stripNukta = true, withVishraams ) => line
     const [ firstLetter, secondLetter = '' ] = word
     const lastLetter = word[ word.length - 1 ]
 
-    //* Do not include any line terminators in first letters
-    if ( lineTerminators.has( firstLetter ) ) { return '' }
-
     // Capture letter after ASCII sihari, if present
     const letter = firstLetter === 'i' ? secondLetter : firstLetter
 
-    // Capture the vishraam char, if it exists and stripVishraams is not set
-    const vishraamChar = withVishraams && vishraams.includes( lastLetter ) ? lastLetter : ''
+    // Capture the vishraam char, if it exists
+    const vishraamChar = vishraams.includes( lastLetter ) ? lastLetter : ''
 
     // Return base letter if enabled and a base letter exists, along with the optional vishraam char
-    return `${stripNukta ? combinedBaseLetterMap[ letter ] || letter : letter}${vishraamChar}`
+    return `${letter}${vishraamChar}`
   } )
   // Join into continuous string
   .join( '' )

--- a/test/firstLetters.spec.js
+++ b/test/firstLetters.spec.js
@@ -5,9 +5,10 @@ const { firstLetters } = require( '../index' )
 
 describe( 'firstLetters()', () => {
   const lines = [
-    [ 'hir hir nwmu jphu mn myry muiK gurmuiK pRIiq lgwqI ]', 'hhnjmmmgpl' ],
-    [ 'iZir&qym sMdUk* drIXw AmIk* ]', 'gsdA' ],
-    [ 'ijs no ik®pw krih iqin nwmu rqnu pwieAw ]', 'jnkkqnrp' ],
+    [ 'hir hir nwmu jphu mn myry muiK gurmuiK pRIiq lgwqI ]', 'hhnjmmmgpl]' ],
+    [ 'iZir&qym sMdUk* drIXw AmIk* ]', 'ZsdA]' ],
+    [ 'ijs no ik®pw krih iqin nwmu rqnu pwieAw ]', 'jnkkqnrp]' ],
+    [ 'sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', 'sm.smr;P.mn,dv]' ],
   ]
 
   lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
@@ -15,54 +16,16 @@ describe( 'firstLetters()', () => {
   } ) )
 } )
 
-describe( 'firstLetters() with stripNukta=false', () => {
-  const lines = [
-    [ 'iZir&qym sMdUk* drIXw AmIk* ]', 'ZsdA' ],
-  ]
-
-  lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line, false ) ).to.equal( expectedFirstLetters )
-  } ) )
-} )
-
-describe( 'firstLetters() with stripNukta=true and withVishraams=true', () => {
-  const lines = [
-    [ 'sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', 'sm.smr;P.mn,dv' ],
-  ]
-
-  lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line, true, true ) ).to.equal( expectedFirstLetters )
-  } ) )
-} )
 
 describe( 'firstLetters() with unicode strings', () => {
   const lines = [
-    [ 'ਗੁਰਮੁਖਿ ਲਾਧਾ ਮਨਮੁਖਿ ਗਵਾਇਆ ॥', 'ਗਲਮਗ' ],
-    [ 'ਜਿਨਿ ਹਰਿ ਸੇਵਿਆ ਤਿਨਿ ਸੁਖੁ ਪਾਇਆ ॥', 'ਜਹਸਤਸਪ' ],
-    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'ਗਹਹਨਬਜਹਗ' ],
+    [ 'ਗੁਰਮੁਖਿ ਲਾਧਾ ਮਨਮੁਖਿ ਗਵਾਇਆ ॥', 'ਗਲਮਗ॥' ],
+    [ 'ਜਿਨਿ ਹਰਿ ਸੇਵਿਆ ਤਿਨਿ ਸੁਖੁ ਪਾਇਆ ॥', 'ਜਹਸਤਸਪ॥' ],
+    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'ਗ਼ਹਹਨਬਜ਼ਹਗ' ],
+    [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ॥' ],
   ]
 
   lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
     expect( firstLetters( line ) ).to.equal( expectedFirstLetters )
-  } ) )
-} )
-
-describe( 'firstLetters() with unicode strings and stripNukta=false', () => {
-  const lines = [
-    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ,', 'ਗ਼ਹਹਨਬਜ਼ਹਗ' ],
-  ]
-
-  lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line, false ) ).to.equal( expectedFirstLetters )
-  } ) )
-} )
-
-describe( 'firstLetters() with unicode strings, stripNukta=true, and withVishraams=true', () => {
-  const lines = [
-    [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ' ],
-  ]
-
-  lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line, true, true ) ).to.equal( expectedFirstLetters )
   } ) )
 } )


### PR DESCRIPTION
### Summary of PR
This PR simplifies the usage of `firstLetters` greatly, to remove parameters that can otherwise be achieved by composing `stripAccents()` and `stripEndings()`.

This achieves a less-error prone and more defined usage of this function, as well as greater flexibility in different use-cases.

### Tests for unexpected behavior
- Test Suite

### Time spent on PR
20 mins

### Linked issues
None

### Reviewers
@bhajneet @Sarabveer 