### PR TITLE
feat(firstLetters): support hindi, english transliterations and simplify

### DIFF
--- a/README.hbs
+++ b/README.hbs
@@ -35,7 +35,6 @@ const {
 
 toUnicode('Koj')    // => ਖੋਜ
 toAscii('ਖੋਜ')      // => Koj
-firstLetters('hir hir hir gunI')  // => hhhg
 firstLetters('ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ')   // => ਹਹਹਗ
 toEnglish('hukmI hukmu clwey rwhu ]')  // => hukamee hukam chalaae raahu ||
 toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥')    // => कुल जन मधे मिल्यो सारग पान रे ॥

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Want to speak with us? <p>[![Slack](https://slack.shabados.com/badge.svg)](https
 
 - [Usage](#usage)
 - [API](#api)
-  * [firstLetters(line, [stripNukta], [withVishraams]) ⇒ String](#firstlettersline-stripnukta-withvishraams-%E2%87%92-string)
+  * [firstLetters(line) ⇒ String](#firstlettersline-%E2%87%92-string)
   * [isGurmukhi(text, [exhaustive]) ⇒ boolean](#isgurmukhitext-exhaustive-%E2%87%92-boolean)
   * [stripAccents(text) ⇒ String](#stripaccentstext-%E2%87%92-string)
   * [stripEndings(text) ⇒ String](#stripendingstext-%E2%87%92-string)
@@ -52,7 +52,6 @@ const {
 
 toUnicode('Koj')    // => ਖੋਜ
 toAscii('ਖੋਜ')      // => Koj
-firstLetters('hir hir hir gunI')  // => hhhg
 firstLetters('ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ')   // => ਹਹਹਗ
 toEnglish('hukmI hukmu clwey rwhu ]')  // => hukamee hukam chalaae raahu ||
 toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥')    // => कुल जन मधे मिल्यो सारग पान रे ॥
@@ -73,43 +72,33 @@ Want to play around? [![Try gurmukhi-utils on RunKit](https://badge.runkitcdn.co
 
 ## API
 
-### firstLetters(line, [stripNukta], [withVishraams]) ⇒ <code>String</code>
-Generates the first letters for a given ASCII or unicode Gurmukhi string.
-By default, the function will transform letters with bindi to their simple equivalent,
-for example, zaza to jaja (ਜ਼ => ਜ).
+### firstLetters(line) ⇒ <code>String</code>
+Generates the first letters for a unicode Gurmukhi,
+Hindi transliteration, Shahmukhi transliteration, or English transliteration string.
+Includes any end-word vishraams, and line-end characters.
 
 **Returns**: <code>String</code> - The first letters of each word in the provided Gurmukhi line.  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| line | <code>String</code> |  | The line to generate the first letters for. |
-| [stripNukta] | <code>Boolean</code> | <code>true</code> | If `true`, replaces letters pair bindi (such as ਜ਼) with their equivalent without the bindi (ਜ). Also replaces open oora with closed oora. |
-| [withVishraams] | <code>Boolean</code> | <code>false</code> | Keeps the vishraam characters at the end of each word. |
+| Param | Type | Description |
+| --- | --- | --- |
+| line | <code>String</code> | The line to generate the first letters for. |
 
-**Example** *(Unicode first letters no pair bindi/nukta)*  
+**Example** *(Gurmukhi first letters)*  
 ```js
-firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ') // => ਗਹਹਨਬਜਹਗ
+firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥') // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ॥
 ```
-**Example** *(Unicode first letters with pair bindi/nukta)*  
+**Example** *(Hindi first letters)*  
 ```js
-firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', false) // => ਗ਼ਹਹਨਬਜ਼ਹਗ
+firstLetters('गुरमुखि लाधा मनमुखि गवाइआ ॥') // => गलमग॥
 ```
-**Example** *(Unicode first letters with vishraams)*  
+**Example** *(English first letters)*  
 ```js
-firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ
+firstLetters('sabad marai. so mar rahai; fir. marai na, doojee vaar |') // => sm.smr;f.mn,dv|
 ```
-**Example** *(ASCII first letters no pair bindi/nukta)*  
+**Example** *(Shahmukhi first letters)*  
 ```js
-firstLetters('ijs no ik®pw krih iqin nwmu rqnu pwieAw ]') // => jnkkqnrp
-firstLetters('iZir&qym sMdUk drIXw AmIk ]') // => gsdA
-```
-**Example** *(ASCII first letters with pair bindi/nukta)*  
-```js
-firstLetters('iZir&qym sMdUk* drIXw AmIk* ]', false) // => Zsda
-```
-**Example** *(ASCII first letters with vishraams)*  
-```js
-firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', true, true) // => sm.smr;P.mn,dv
+firstLetters('سبد مرَے. سو مر رهَے; پھِر. مرَے ن, دُوجی وار ۔۔')
+ // => سم.سمر;پ.من,دو۔
 ```
 ### isGurmukhi(text, [exhaustive]) ⇒ <code>boolean</code>
 Checks if first char in string is part of the Gurmukhi Unicode block.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Want to play around? [![Try gurmukhi-utils on RunKit](https://badge.runkitcdn.co
 
 ### firstLetters(line) ⇒ <code>String</code>
 Generates the first letters for a unicode Gurmukhi,
-Hindi transliteration, Shahmukhi transliteration, or English transliteration string.
+Hindi transliteration, or English transliteration string.
 Includes any end-word vishraams, and line-end characters.
 
 **Returns**: <code>String</code> - The first letters of each word in the provided Gurmukhi line.  
@@ -94,11 +94,6 @@ firstLetters('गुरमुखि लाधा मनमुखि गवाइ
 **Example** *(English first letters)*  
 ```js
 firstLetters('sabad marai. so mar rahai; fir. marai na, doojee vaar |') // => sm.smr;f.mn,dv|
-```
-**Example** *(Shahmukhi first letters)*  
-```js
-firstLetters('سبد مرَے. سو مر رهَے; پھِر. مرَے ن, دُوجی وار ۔۔')
- // => سم.سمر;پ.من,دو۔
 ```
 ### isGurmukhi(text, [exhaustive]) ⇒ <code>boolean</code>
 Checks if first char in string is part of the Gurmukhi Unicode block.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Want to speak with us? <p>[![Slack](https://slack.shabados.com/badge.svg)](https
 
 - [Usage](#usage)
 - [API](#api)
-  * [firstLetters(line, [stripNukta], [withVishraams]) ⇒ String](#firstlettersline-stripnukta-withvishraams-%E2%87%92-string)
+  * [firstLetters(line) ⇒ String](#firstlettersline-%E2%87%92-string)
   * [isGurmukhi(text, [exhaustive]) ⇒ boolean](#isgurmukhitext-exhaustive-%E2%87%92-boolean)
   * [stripAccents(text) ⇒ String](#stripaccentstext-%E2%87%92-string)
   * [stripEndings(text) ⇒ String](#stripendingstext-%E2%87%92-string)
@@ -52,7 +52,6 @@ const {
 
 toUnicode('Koj')    // => ਖੋਜ
 toAscii('ਖੋਜ')      // => Koj
-firstLetters('hir hir hir gunI')  // => hhhg
 firstLetters('ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ')   // => ਹਹਹਗ
 toEnglish('hukmI hukmu clwey rwhu ]')  // => hukamee hukam chalaae raahu ||
 toHindi('ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵੋਿ ਸਾਰਗ ਪਾਨ ਰੇ ॥')    // => कुल जन मधे मिल्यो सारग पान रे ॥
@@ -73,43 +72,33 @@ Want to play around? [![Try gurmukhi-utils on RunKit](https://badge.runkitcdn.co
 
 ## API
 
-### firstLetters(line, [stripNukta], [withVishraams]) ⇒ <code>String</code>
-Generates the first letters for a given ASCII or unicode Gurmukhi string.
-By default, the function will transform letters with bindi to their simple equivalent,
-for example, zaza to jaja (ਜ਼ => ਜ).
+### firstLetters(line) ⇒ <code>String</code>
+Generates the first letters for a unicode Gurmukhi,
+Hindi transliteration, Shahmukhi transliteration, or English transliteration string.
+Includes any end-word vishraams, and line-end characters.
 
 **Returns**: <code>String</code> - The first letters of each word in the provided Gurmukhi line.  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| line | <code>String</code> |  | The line to generate the first letters for. |
-| [stripNukta] | <code>Boolean</code> | <code>true</code> | If `true`, replaces letters pair bindi (such as ਜ਼) with their equivalent without the bindi (ਜ). Also replaces open oora with closed oora. |
-| [withVishraams] | <code>Boolean</code> | <code>false</code> | Keeps the vishraam characters at the end of each word. |
+| Param | Type | Description |
+| --- | --- | --- |
+| line | <code>String</code> | The line to generate the first letters for. |
 
-**Example** *(Unicode first letters no pair bindi/nukta)*  
+**Example** *(Gurmukhi first letters)*  
 ```js
-firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ') // => ਗਹਹਨਬਜਹਗ
+firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥') // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ॥
 ```
-**Example** *(Unicode first letters with pair bindi/nukta)*  
+**Example** *(Hindi first letters)*  
 ```js
-firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', false) // => ਗ਼ਹਹਨਬਜ਼ਹਗ
+firstLetters('गुरमुखि लाधा मनमुखि गवाइआ ॥') // => गलमग॥
 ```
-**Example** *(Unicode first letters with vishraams)*  
+**Example** *(English first letters)*  
 ```js
-firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ
+firstLetters('sabad marai. so mar rahai; fir. marai na, doojee vaar |') // => sm.smr;f.mn,dv|
 ```
-**Example** *(ASCII first letters no pair bindi/nukta)*  
+**Example** *(Shahmukhi first letters)*  
 ```js
-firstLetters('ijs no ik®pw krih iqin nwmu rqnu pwieAw ]') // => jnkkqnrp
-firstLetters('iZir&qym sMdUk drIXw AmIk ]') // => gsdA
-```
-**Example** *(ASCII first letters with pair bindi/nukta)*  
-```js
-firstLetters('iZir&qym sMdUk* drIXw AmIk* ]', false) // => Zsda
-```
-**Example** *(ASCII first letters with vishraams)*  
-```js
-firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', true, true) // => sm.smr;P.mn,dv
+firstLetters('سبد مرَے. سو مر رهَے; پھِر. مرَے ن, دُوجی وار ۔۔')
+ // => سم.سمر;پ.من,دو۔
 ```
 ### isGurmukhi(text, [exhaustive]) ⇒ <code>boolean</code>
 Checks if first char in string is part of the Gurmukhi Unicode block.

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ Want to play around? [![Try gurmukhi-utils on RunKit](https://badge.runkitcdn.co
 
 ### firstLetters(line) ⇒ <code>String</code>
 Generates the first letters for a unicode Gurmukhi,
-Hindi transliteration, Shahmukhi transliteration, or English transliteration string.
+Hindi transliteration, or English transliteration string.
 Includes any end-word vishraams, and line-end characters.
 
 **Returns**: <code>String</code> - The first letters of each word in the provided Gurmukhi line.  
@@ -94,11 +94,6 @@ firstLetters('गुरमुखि लाधा मनमुखि गवाइ
 **Example** *(English first letters)*  
 ```js
 firstLetters('sabad marai. so mar rahai; fir. marai na, doojee vaar |') // => sm.smr;f.mn,dv|
-```
-**Example** *(Shahmukhi first letters)*  
-```js
-firstLetters('سبد مرَے. سو مر رهَے; پھِر. مرَے ن, دُوجی وار ۔۔')
- // => سم.سمر;پ.من,دو۔
 ```
 ### isGurmukhi(text, [exhaustive]) ⇒ <code>boolean</code>
 Checks if first char in string is part of the Gurmukhi Unicode block.

--- a/example.js
+++ b/example.js
@@ -13,7 +13,6 @@ const {
 
 console.log(toUnicode( 'Koj' ))
 console.log(toAscii('ਖੋਜ'))
-console.log(firstLetters( 'hir hir hir gun gwvhu ]' ))
 console.log(firstLetters( 'ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ' ))
 console.log(toEnglish( 'ਹੁਕਮੀ ਹੁਕਮੁ ਚਲਾਏ ਰਾਹੁ ॥' ))
 console.log(toShahmukhi( 'ਹਰਿ ਹਰਿ ਹਰਿ ਗੁਨੀ' ))

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export function toHindi(text: string): string
 
 export function toShamukhi(text: string): string
 
-export function firstLetters(text: string, stripNukta?: boolean = true, withVishraams?: boolean): string
+export function firstLetters(text: string): string
 
 export function isGurmukhi(text: string, exhaustive?: boolean): boolean
 

--- a/lib/firstLetters.js
+++ b/lib/firstLetters.js
@@ -32,7 +32,7 @@ const firstLetters = line => line
     // Capture the vishraam char, if it exists
     const vishraamChar = vishraams.includes( lastLetter ) ? lastLetter : ''
 
-    // Return base letter if enabled and a base letter exists, along with the optional vishraam char
+    // Return base letter along with potential vishraam character
     return `${letter}${vishraamChar}`
   } )
   // Join into continuous string

--- a/lib/firstLetters.js
+++ b/lib/firstLetters.js
@@ -2,7 +2,7 @@ const vishraams = Object.values( require( './vishraams.json' ) )
 
 /**
  * Generates the first letters for a unicode Gurmukhi,
- * Hindi transliteration, Shahmukhi transliteration, or English transliteration string.
+ * Hindi transliteration, or English transliteration string.
  * Includes any end-word vishraams, and line-end characters.
  *
  * @param {String} line The line to generate the first letters for.
@@ -16,10 +16,6 @@ const vishraams = Object.values( require( './vishraams.json' ) )
  *
  * @example <caption>English first letters</caption>
  * firstLetters('sabad marai. so mar rahai; fir. marai na, doojee vaar |') // => sm.smr;f.mn,dv|
- *
- * @example <caption>Shahmukhi first letters</caption>
- * firstLetters('سبد مرَے. سو مر رهَے; پھِر. مرَے ن, دُوجی وار ۔۔')
- *  // => سم.سمر;پ.من,دو۔
  */
 const firstLetters = line => line
   // Split into words

--- a/lib/firstLetters.js
+++ b/lib/firstLetters.js
@@ -1,80 +1,39 @@
 const vishraams = Object.values( require( './vishraams.json' ) )
 
-// The mappings from the letter-variations to simple Gurmukhi letters in ASCII.
-const asciiBaseLetterMap = {
-  E: 'a', // Open oora -> oora
-  S: 's', // Shasha -> sasa
-  z: 'j', // zaza -> jaja
-  Z: 'g', // gaga pair bindi -> gaga
-  L: 'l', // lala pair bindi -> lala
-  '^': 'K', // Khakha pair bindi -> khakha
-  '&': 'P', // Fafa pair bindi -> Fafa
-}
-
-const unicodeBaseLetterMap = {
-  ਓ: 'ੳ', // Open oora -> oora
-  ਸ਼: 'ਸ', // Shasha -> sasa
-  ਜ਼: 'ਜ', // zaza -> jaja
-  ਗ਼: 'ਗ', // gaga pair bindi -> gaga
-  ਲ਼: 'ਲ', // lala pair bindi -> lala
-  ਖ਼: 'ਖ', // Khakha pair bindi -> khakha
-  ਫ਼: 'ਫ', // Fafa pair bindi -> Fafa
-}
-
-// Specifies the line terminator characters for both ASCII and unicode Gurmukhi
-const lineTerminators = new Set( [ '।', '॥', ']', '[' ] )
-
-// Combine the base letter maps
-const combinedBaseLetterMap = { ...asciiBaseLetterMap, ...unicodeBaseLetterMap }
-
 /**
- * Generates the first letters for a given ASCII or unicode Gurmukhi string.
- * By default, the function will transform letters with bindi to their simple equivalent,
- * for example, zaza to jaja (ਜ਼ => ਜ).
+ * Generates the first letters for a unicode Gurmukhi,
+ * Hindi transliteration, Shahmukhi transliteration, or English transliteration string.
+ * Includes any end-word vishraams, and line-end characters.
+ *
  * @param {String} line The line to generate the first letters for.
- * @param {Boolean} [stripNukta=true] If `true`, replaces letters pair bindi (such as ਜ਼)
- * with their equivalent without the bindi (ਜ). Also replaces open oora with closed oora.
- * @param {Boolean} [withVishraams=false] Keeps the vishraam characters at the end of each word.
  * @returns {String} The first letters of each word in the provided Gurmukhi line.
  *
- * @example <caption>Unicode first letters no pair bindi/nukta</caption>
- * firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ') // => ਗਹਹਨਬਜਹਗ
+ * @example <caption>Gurmukhi first letters</caption>
+ * firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥') // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ॥
  *
- * @example <caption>Unicode first letters with pair bindi/nukta</caption>
- * firstLetters('ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', false) // => ਗ਼ਹਹਨਬਜ਼ਹਗ
+ * @example <caption>Hindi first letters</caption>
+ * firstLetters('गुरमुखि लाधा मनमुखि गवाइआ ॥') // => गलमग॥
  *
- * @example <caption>Unicode first letters with vishraams</caption>
- * firstLetters('ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', true, true) // => ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ
+ * @example <caption>English first letters</caption>
+ * firstLetters('sabad marai. so mar rahai; fir. marai na, doojee vaar |') // => sm.smr;f.mn,dv|
  *
- * @example <caption>ASCII first letters no pair bindi/nukta</caption>
- * firstLetters('ijs no ik®pw krih iqin nwmu rqnu pwieAw ]') // => jnkkqnrp
- * firstLetters('iZir&qym sMdUk drIXw AmIk ]') // => gsdA
- *
- * @example <caption>ASCII first letters with pair bindi/nukta</caption>
- * firstLetters('iZir&qym sMdUk* drIXw AmIk* ]', false) // => Zsda
- *
- * @example <caption>ASCII first letters with vishraams</caption>
- * firstLetters('sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', true, true) // => sm.smr;P.mn,dv
+ * @example <caption>Shahmukhi first letters</caption>
+ * firstLetters('سبد مرَے. سو مر رهَے; پھِر. مرَے ن, دُوجی وار ۔۔')
+ *  // => سم.سمر;پ.من,دو۔
  */
-const firstLetters = ( line, stripNukta = true, withVishraams ) => line
+const firstLetters = line => line
   // Split into words
   .split( ' ' )
   // Grab correct letter of each word
   .map( word => {
-    const [ firstLetter, secondLetter = '' ] = word
+    const [ letter ] = word
     const lastLetter = word[ word.length - 1 ]
 
-    //* Do not include any line terminators in first letters
-    if ( lineTerminators.has( firstLetter ) ) { return '' }
-
-    // Capture letter after ASCII sihari, if present
-    const letter = firstLetter === 'i' ? secondLetter : firstLetter
-
-    // Capture the vishraam char, if it exists and stripVishraams is not set
-    const vishraamChar = withVishraams && vishraams.includes( lastLetter ) ? lastLetter : ''
+    // Capture the vishraam char, if it exists
+    const vishraamChar = vishraams.includes( lastLetter ) ? lastLetter : ''
 
     // Return base letter if enabled and a base letter exists, along with the optional vishraam char
-    return `${stripNukta ? combinedBaseLetterMap[ letter ] || letter : letter}${vishraamChar}`
+    return `${letter}${vishraamChar}`
   } )
   // Join into continuous string
   .join( '' )

--- a/test/firstLetters.spec.js
+++ b/test/firstLetters.spec.js
@@ -1,13 +1,13 @@
 const { expect } = require( 'chai' )
 
-const { firstLetters } = require( '../index' )
+const { firstLetters, toHindi, toEnglish, toShahmukhi } = require( '../index' )
 
-
-describe( 'firstLetters()', () => {
+describe( 'firstLetters(gurmukhi)', () => {
   const lines = [
-    [ 'hir hir nwmu jphu mn myry muiK gurmuiK pRIiq lgwqI ]', 'hhnjmmmgpl' ],
-    [ 'iZir&qym sMdUk* drIXw AmIk* ]', 'gsdA' ],
-    [ 'ijs no ik®pw krih iqin nwmu rqnu pwieAw ]', 'jnkkqnrp' ],
+    [ 'ਗੁਰਮੁਖਿ ਲਾਧਾ ਮਨਮੁਖਿ ਗਵਾਇਆ ॥', 'ਗਲਮਗ॥' ],
+    [ 'ਜਿਨਿ ਹਰਿ ਸੇਵਿਆ ਤਿਨਿ ਸੁਖੁ ਪਾਇਆ ॥', 'ਜਹਸਤਸਪ॥' ],
+    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'ਗ਼ਹਹਨਬਜ਼ਹਗ' ],
+    [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ॥' ],
   ]
 
   lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
@@ -15,54 +15,41 @@ describe( 'firstLetters()', () => {
   } ) )
 } )
 
-describe( 'firstLetters() with stripNukta=false', () => {
+describe( 'firstLetters(hindi)', () => {
   const lines = [
-    [ 'iZir&qym sMdUk* drIXw AmIk* ]', 'ZsdA' ],
-  ]
-
-  lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line, false ) ).to.equal( expectedFirstLetters )
-  } ) )
-} )
-
-describe( 'firstLetters() with stripNukta=true and withVishraams=true', () => {
-  const lines = [
-    [ 'sbid mrY. so mir rhY; iPir. mrY n, dUjI vwr ]', 'sm.smr;P.mn,dv' ],
-  ]
-
-  lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line, true, true ) ).to.equal( expectedFirstLetters )
-  } ) )
-} )
-
-describe( 'firstLetters() with unicode strings', () => {
-  const lines = [
-    [ 'ਗੁਰਮੁਖਿ ਲਾਧਾ ਮਨਮੁਖਿ ਗਵਾਇਆ ॥', 'ਗਲਮਗ' ],
-    [ 'ਜਿਨਿ ਹਰਿ ਸੇਵਿਆ ਤਿਨਿ ਸੁਖੁ ਪਾਇਆ ॥', 'ਜਹਸਤਸਪ' ],
-    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'ਗਹਹਨਬਜਹਗ' ],
-  ]
+    [ 'ਗੁਰਮੁਖਿ ਲਾਧਾ ਮਨਮੁਖਿ ਗਵਾਇਆ ॥', 'गलमग॥' ],
+    [ 'ਜਿਨਿ ਹਰਿ ਸੇਵਿਆ ਤਿਨਿ ਸੁਖੁ ਪਾਇਆ ॥', 'जहसतसप॥' ],
+    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'ग़हहनबज़हग' ],
+    [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'सम.समर;फ.मन,दव॥' ],
+  ].map( ( [ input, output ] ) => [ toHindi( input ), output ] )
 
   lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
     expect( firstLetters( line ) ).to.equal( expectedFirstLetters )
   } ) )
 } )
 
-describe( 'firstLetters() with unicode strings and stripNukta=false', () => {
+describe( 'firstLetters(shahmukhi)', () => {
   const lines = [
-    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ,', 'ਗ਼ਹਹਨਬਜ਼ਹਗ' ],
-  ]
+    [ 'ਗੁਰਮੁਖਿ ਲਾਧਾ ਮਨਮੁਖਿ ਗਵਾਇਆ ॥', 'گلمگ۔' ],
+    [ 'ਜਿਨਿ ਹਰਿ ਸੇਵਿਆ ਤਿਨਿ ਸੁਖੁ ਪਾਇਆ ॥', 'جهستسپ۔' ],
+    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'غههنبزهگ' ],
+    [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'سم.سمر;پ.من,دو۔' ],
+  ].map( ( [ input, output ] ) => [ toShahmukhi( input ), output ] )
 
   lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line, false ) ).to.equal( expectedFirstLetters )
+    expect( firstLetters( line ) ).to.equal( expectedFirstLetters )
   } ) )
 } )
 
-describe( 'firstLetters() with unicode strings, stripNukta=true, and withVishraams=true', () => {
+describe( 'firstLetters(english)', () => {
   const lines = [
-    [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'ਸਮ.ਸਮਰ;ਫ.ਮਨ,ਦਵ' ],
-  ]
+    [ 'ਗੁਰਮੁਖਿ ਲਾਧਾ ਮਨਮੁਖਿ ਗਵਾਇਆ ॥', 'glmg|' ],
+    [ 'ਜਿਨਿ ਹਰਿ ਸੇਵਿਆ ਤਿਨਿ ਸੁਖੁ ਪਾਇਆ ॥', 'jhstsp|' ],
+    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'ghhnbzhg' ],
+    [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'sm.smr;f.mn,dv|' ],
+  ].map( ( [ input, output ] ) => [ toEnglish( input ), output ] )
 
   lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line, true, true ) ).to.equal( expectedFirstLetters )
+    expect( firstLetters( line ) ).to.equal( expectedFirstLetters )
   } ) )
 } )

--- a/test/firstLetters.spec.js
+++ b/test/firstLetters.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require( 'chai' )
 
-const { firstLetters, toHindi, toEnglish, toShahmukhi } = require( '../index' )
+const { firstLetters, toHindi, toEnglish } = require( '../index' )
 
 describe( 'firstLetters(gurmukhi)', () => {
   const lines = [
@@ -22,19 +22,6 @@ describe( 'firstLetters(hindi)', () => {
     [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'ग़हहनबज़हग' ],
     [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'सम.समर;फ.मन,दव॥' ],
   ].map( ( [ input, output ] ) => [ toHindi( input ), output ] )
-
-  lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
-    expect( firstLetters( line ) ).to.equal( expectedFirstLetters )
-  } ) )
-} )
-
-describe( 'firstLetters(shahmukhi)', () => {
-  const lines = [
-    [ 'ਗੁਰਮੁਖਿ ਲਾਧਾ ਮਨਮੁਖਿ ਗਵਾਇਆ ॥', 'گلمگ۔' ],
-    [ 'ਜਿਨਿ ਹਰਿ ਸੇਵਿਆ ਤਿਨਿ ਸੁਖੁ ਪਾਇਆ ॥', 'جهستسپ۔' ],
-    [ 'ਗ਼ੈਰਿ ਹਮਦਿ ਹੱਕ ਨਿਆਇਦ ਬਰ ਜ਼ਬਾਨਮ ਹੀਚ ਗਾਹ', 'غههنبزهگ' ],
-    [ 'ਸਬਦਿ ਮਰੈ. ਸੋ ਮਰਿ ਰਹੈ; ਫਿਰਿ. ਮਰੈ ਨ, ਦੂਜੀ ਵਾਰ ॥', 'سم.سمر;پ.من,دو۔' ],
-  ].map( ( [ input, output ] ) => [ toShahmukhi( input ), output ] )
 
   lines.map( ( [ line, expectedFirstLetters ] ) => it( `should generate first letters for '${line}' as '${expectedFirstLetters}'`, () => {
     expect( firstLetters( line ) ).to.equal( expectedFirstLetters )


### PR DESCRIPTION
## Summary of PR

> Breaking change

This PR simplifies the usage of `firstLetters` greatly, removing ASCII support and removing parameters that can otherwise be achieved by composing `stripAccents()`, `toUnicode()`, `stripEndings()`. 

This achieves a less-error prone and more defined usage of this function, as well as greater flexibility in different use-cases.

## Tests for unexpected behavior
- Test Suite

## Time spent on PR
40 mins

## Linked issues
Closes #105

## Reviewers
@bhajneet @Sarabveer