### PR TITLE
fix: rectify conditional logic for toEnglish

### DIFF
--- a/lib/toEnglish.js
+++ b/lib/toEnglish.js
@@ -10,6 +10,9 @@ const spaceCharsRegex = `([${spaceChars.join( '' ).replace( /[.*+?^${}()|[\]\\]/
 // Characters that should be supressed into empty characters
 const supressions = [ '@', '`', '~', '¤', 'ª', '°', 'Ç', 'Ó', 'Ô', 'Ø', 'æ', 'Œ', '‰' ]
 
+// Characters that should be left as is
+const ignore = [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '.', ',', ';', '₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉' ]
+
 // The transliteration mappings from ASCII Gurmukhi to english
 const transliterationMap = {
   ' ': ' ',
@@ -98,6 +101,8 @@ const transliterationMap = {
   '†': 'tt',
   // Expand out supressions as char: ''
   ...supressions.reduce( ( chars, char ) => ( { ...chars, [ char ]: '' } ), {} ),
+  // Expand out ignore as self
+  ...ignore.reduce( ( chars, char ) => ( { ...chars, [ char ]: char } ), {} ),
 }
 
 // Replacements for the initial input
@@ -147,6 +152,7 @@ const finalReplacements = Object.entries( {
   '\\(': '',
   '\\)': '',
   aaa: 'aa',
+  aai: 'ai',
   eee: 'ee',
   nn: 'n',
   eeaa: 'eea',
@@ -190,7 +196,8 @@ const toEnglish = ( line ) => {
       const nextNextLetter = line[ index + 2 ] || ''
 
       // Map letter using transliteration map
-      let mappedLetter = transliterationMap[ letter ] || letter
+      // If letter is unmappable, then suppress it
+      let mappedLetter = transliterationMap[ letter ] || ''
 
       // Add in extra `a` if every rule is met
       if ( extraARules.every( ( fn ) => fn( mappedLetter, nextLetter, nextNextLetter ) ) ) { mappedLetter += 'a' }

--- a/test/toEnglish.spec.js
+++ b/test/toEnglish.spec.js
@@ -30,6 +30,7 @@ const transliterations = [
   [ 'ਭਾਉ', 'bhaau' ],
   [ 'ਸਤਿਗੁਰੁ ਸਤਿਗੁਰੁ ਸਚੁ; ਸਚੁ ਹਰਿ ਹਰਿ ਹਿੰਙੁ', 'satigur satigur sach; sach har har hing' ],
   [ 'ਸੁ ਉ ਜੁ', 'su u ju' ],
+  [ 'ਆਪੀਨੑੈ', 'aapeenai' ],
 ]
 
 describe( 'toEnglish()', () => {


### PR DESCRIPTION
### Summary of PR
the logic was:

```
let mappedLetter = transliterationMap[ letter ] || letter
```

so if the mapped letter were `''` (empty string) it would result in false, therefore passing through all the suppressed characters.

new method is now:

```
let mappedLetter = transliterationMap[ letter ] || ''
```

and we have explicitly added a bunch of pass through characters in the ignore array/set. now all the tests pass, if there is something not found in the transliterationMap it will be suppressed / hidden from end result, which is not ideal, but better than what we had before I suppose.

### Tests for unexpected behavior
- tests pass

### Time spent on PR
30 mins

### Linked issues
Fix #185 