### PR TITLE
fix(toUnicode): Swap 'uo' (Aunkarh+Hora) to Unicode compliant 'ou' (Hora+Aunkarh)

### DIFF
--- a/lib/toUnicode.js
+++ b/lib/toUnicode.js
@@ -15,6 +15,7 @@ const replacements = [
   [ /([MµyY])([uU])/ug, '$2$1' ], // Switch around lava/dulava/tipee with aunkar/dulankar
   [ /`([wWIoOyYR®H§´ÍÏçœ˜†uU])/ug, '$1`' ], // Place adhak at end when vowels are either side
   [ /i([´Î])/ug, '$1i' ], // Swap i with ´ or Î
+  [ /uo/ug, 'ou' ], // Swap aunkarh+hora for unicode compliant hora+aunakarh
 ]
 
 // Precompute the replacements and mappings

--- a/test/toUnicode.spec.js
+++ b/test/toUnicode.spec.js
@@ -6,6 +6,8 @@ const words = [
   [ 'ihr', 'ਹਿਰ' ],
   [ 'imil´o', 'ਮਿਲੵਿੋ' ],
   [ 'iBÎo', 'ਭ੍ਯਿੋ' ],
+  [ 'quohI', 'ਤੋੁਹੀ' ],
+  [ 'qouhI', 'ਤੋੁਹੀ' ],
   [ 'kul jn mDy imil´o swrg pwn ry ]', 'ਕੁਲ ਜਨ ਮਧੇ ਮਿਲੵਿੋ ਸਾਰਗ ਪਾਨ ਰੇ ॥' ],
   [ 'qU pRB dwqw dwin miq pUrw hm Qwry ByKwrI jIau ]', 'ਤੂ ਪ੍ਰਭ ਦਾਤਾ ਦਾਨਿ ਮਤਿ ਪੂਰਾ ਹਮ ਥਾਰੇ ਭੇਖਾਰੀ ਜੀਉ ॥' ],
   [ 'so bRhmu AjonI hY BI honI Gt BIqir dyKu murwrI jIau ]2]', 'ਸੋ ਬ੍ਰਹਮੁ ਅਜੋਨੀ ਹੈ ਭੀ ਹੋਨੀ ਘਟ ਭੀਤਰਿ ਦੇਖੁ ਮੁਰਾਰੀ ਜੀਉ ॥੨॥' ],


### PR DESCRIPTION
<!-- Please title as if this PR were a single commit to our main branch. -->
<!-- https://docs.shabados.com/community/coding-guidelines#commit-messages -->
<!-- Also don't forget to add any reviewer(s) and link the related issue! -->

### Summary

<img width="632" alt="image" src="https://user-images.githubusercontent.com/4297171/158912423-6432c1e9-2497-493a-aba1-60c14a82ab96.png">

As mentioned in the Unicode standard, the combination should be `U+0A4B` + `U+0A41`

### Test

Tests were added. Output renders fine on iOS 15.3.1 on an iPhone 13.

![image](https://user-images.githubusercontent.com/4297171/158912273-2fc7e504-e2d9-48d7-9e20-b458f30b5b62.png)

### Duration
